### PR TITLE
Fixed problem with merge.startingFrom/mergeWith on a merge node

### DIFF
--- a/test/jtext_extension.json
+++ b/test/jtext_extension.json
@@ -121,5 +121,15 @@
             ]
         ]
     }
+},
+{
+    "say": {
+        "Fn::Join": [
+            "",
+            [
+                "Hello, I must be going\n"
+            ]
+        ]
+    }
 }
 ]

--- a/test/jtext_extension.yaml
+++ b/test/jtext_extension.yaml
@@ -41,3 +41,9 @@ main:
 main:
     say: !jtext |
         Hello !{Ref: FirstName!}
+---
+# No ref
+main:
+    say: !jtext |
+        Hello, I must be going
+

--- a/test/merge_extension.json
+++ b/test/merge_extension.json
@@ -170,6 +170,21 @@
 ,
 {
     "firstLevel1": {
+        "secondLevel1": "value1 do not override",
+        "secondLevel2": "value2 override",
+        "secondLevel3": "value3 override",
+        "secondLevel4": "value4 override",
+        "secondLevel5": "value5 do not override",
+        "secondLevel6": "value6 override",
+        "secondLevel7": "value7 override",
+        "secondLevel8": "value8 do not override",
+        "secondLevel9": "value9 override",
+        "secondLevel0": "value0 do not override"
+    }
+}
+,
+{
+    "firstLevel1": {
         "secondLevel1": "value1 final override",
         "secondLevel2": "value2 final override",
         "secondLevel3": "value3 final override",

--- a/test/merge_extension.json
+++ b/test/merge_extension.json
@@ -130,4 +130,51 @@
         ]
     }
 }
+,
+{
+    "top": [
+        "value1",
+        "value2",
+        "value2",
+        "value3"
+    ]
+}
+,
+{
+    "top": [
+        "value1",
+        { "key1": "value1", "key2": "override", "key3": "value3"},
+        "value3"
+    ]
+}
+,
+{
+    "firstLevel1": {
+        "secondLevel11": "value11 do not override",
+        "secondLevel12": "value12 override",
+        "secondLevel13": "value13 not an override"
+    },
+    "firstLevel2": {
+        "secondLevel21": "value21 do not override",
+        "secondLevel22": "value22 override",
+        "secondLevel23": "value23 override",
+        "secondLevel24": "value24 override",
+        "secondLevel25": "value25 do not override",
+        "secondLevel26": "value26 override",
+        "secondLevel27": "value27 override",
+        "secondLevel28": "value28 do not override",
+        "secondLevel29": "value29 override",
+        "secondLevel30": "value30 do not override"
+    }
+}
+,
+{
+    "firstLevel1": {
+        "secondLevel1": "value1 final override",
+        "secondLevel2": "value2 final override",
+        "secondLevel3": "value3 final override",
+        "secondLevel4": "value4 final override",
+        "secondLevel5": "value5 final override"
+    }
+}
 ]

--- a/test/merge_extension.yaml
+++ b/test/merge_extension.yaml
@@ -223,6 +223,41 @@ main: !merge
                 secondLevel29: value29 override
                 secondLevel30: value30 do not override
 ---
+# Embedded merges in startingFrom and mergeWith (root)
+main: !merge
+    startingFrom:
+        firstLevel1: !merge
+            startingFrom:
+                # firstLevel1 - initial
+                secondLevel1: value1 do not override
+                secondLevel2: value2 override in firstlevel1 - override 1
+                secondLevel3: value3 override in firstlevel1 - override 2
+                secondLevel4: value4 override in firstlevel1 - override 3
+
+            mergeWith:
+                # firstLevel1 - override 1
+                secondLevel2: value2 override
+                secondLevel5: value5 do not override
+                secondLevel6: value6 override in firstlevel1 - override 2
+                secondLevel7: value7 override in firstlevel1 - override 3
+
+    mergeWith: !merge
+        startingFrom:
+            firstLevel1:
+                # firstLevel1 - override 2
+                secondLevel3: value3 override
+                secondLevel6: value6 override
+                secondLevel8: value8 do not override
+                secondLevel9: value9 override in firstlevel1 - override 3
+
+        mergeWith:
+            firstLevel1:
+                # firstLevel1 - override 3
+                secondLevel4: value4 override
+                secondLevel7: value7 override
+                secondLevel9: value9 override
+                secondLevel0: value0 do not override
+---
 # Many overrides of same key
 main: !merge
     startingFrom: !merge
@@ -242,16 +277,17 @@ main: !merge
                 secondLevel4: value4 first override
                 secondLevel5: value5 override in Overrides 2, and 3
 
-    mergeWith:
-        firstLevel1: !merge
-            startingFrom:
+    mergeWith: !merge
+        startingFrom:
+            firstLevel1:
                 # Override 2
                 secondLevel1: value1 final override
                 secondLevel2: value2 first override
                 secondLevel4: value4 second override
                 secondLevel5: value5 first override
 
-            mergeWith:
+        mergeWith:
+            firstLevel1:
                 # Override 3
                 secondLevel2: value2 final override
                 secondLevel3: value3 final override

--- a/test/merge_extension.yaml
+++ b/test/merge_extension.yaml
@@ -158,3 +158,102 @@ main:
             firstLevel1:
                 - value2
                 - value3
+---
+# Merging merging top-level lists with some duplicates
+main:
+    top: !merge
+        startingFrom:
+            - value1
+            - value2
+        mergeWith:
+            - value2
+            - value3
+---
+# Merge on a list item
+main:
+    top:
+        - value1
+        - !merge
+            startingFrom:
+                key1: value1
+                key2: value2
+            mergeWith:
+                key2: override
+                key3: value3
+        - value3
+---
+# Embedded merges in startingFrom (root) and mergeWith
+main: !merge
+    startingFrom: !merge
+        startingFrom:
+            firstLevel1:
+                secondLevel11: value11 do not override
+                secondLevel12: value12 please override
+            firstLevel2:
+                # firstLevel2 - initial
+                secondLevel21: value21 do not override
+                secondLevel22: value22 override in firstlevel2 - override 1
+                secondLevel23: value23 override in firstlevel2 - override 2
+                secondLevel24: value24 override in firstlevel2 - override 3
+
+        mergeWith:
+            firstLevel1:
+                secondLevel12: value12 override
+                secondLevel13: value13 not an override
+            firstLevel2:
+                # firstLevel2 - override 1
+                secondLevel22: value22 override
+                secondLevel25: value25 do not override
+                secondLevel26: value26 override in firstlevel2 - override 2
+                secondLevel27: value27 override in firstlevel2 - override 3
+
+    mergeWith:
+        firstLevel2: !merge
+            startingFrom:
+                # firstLevel2 - override 2
+                secondLevel23: value23 override
+                secondLevel26: value26 override
+                secondLevel28: value28 do not override
+                secondLevel29: value29 override in firstlevel2 - override 3
+
+            mergeWith:
+                # firstLevel2 - override 3
+                secondLevel24: value24 override
+                secondLevel27: value27 override
+                secondLevel29: value29 override
+                secondLevel30: value30 do not override
+---
+# Many overrides of same key
+main: !merge
+    startingFrom: !merge
+        startingFrom:
+            firstLevel1:
+                # Initial values
+                secondLevel1: value1 override in Overrides 1 and 2
+                secondLevel2: value2 override in Overrides 2 and 3
+                secondLevel3: value3 override in Overrides 1, and 3
+                secondLevel4: value4 override in Overrides 1, 2, and 3
+
+        mergeWith:
+            firstLevel1:
+                # Override 1
+                secondLevel1: value1 first override
+                secondLevel3: value3 first override
+                secondLevel4: value4 first override
+                secondLevel5: value5 override in Overrides 2, and 3
+
+    mergeWith:
+        firstLevel1: !merge
+            startingFrom:
+                # Override 2
+                secondLevel1: value1 final override
+                secondLevel2: value2 first override
+                secondLevel4: value4 second override
+                secondLevel5: value5 first override
+
+            mergeWith:
+                # Override 3
+                secondLevel2: value2 final override
+                secondLevel3: value3 final override
+                secondLevel4: value4 final override
+                secondLevel5: value5 final override

--- a/test/remove_extension.json
+++ b/test/remove_extension.json
@@ -69,4 +69,8 @@
 }
 ,
 {}
+,
+{
+    "firstLevel1": "value1"
+}
 ]

--- a/test/remove_extension.yaml
+++ b/test/remove_extension.yaml
@@ -124,3 +124,11 @@ main: !merge
         firstLevel1: !remove
         firstLevel2: !remove
         firstLevel3: !remove
+---
+# Removing non-existent node
+main: !merge
+    startingFrom:
+        firstLevel1: value1
+    mergeWith:
+        # Ignored
+        firstLevel2: !remove

--- a/test/replace_extension.json
+++ b/test/replace_extension.json
@@ -121,4 +121,13 @@
         "secondLevel3": "value3"
     }
 }
+,
+{
+    "firstLevel1": {
+        "secondLevel1": "value1"
+    },
+    "firstLevel2": {
+        "secondLevel2": "value2"
+    }
+}
 ]

--- a/test/replace_extension.yaml
+++ b/test/replace_extension.yaml
@@ -149,3 +149,13 @@ main: !merge
             secondLevel2: value3
         firstLevel3: !replace
             secondLevel3: value3
+---
+# Replacing non-existent node
+main: !merge
+    startingFrom:
+        firstLevel1:
+            secondLevel1: value1
+    mergeWith:
+        # No node to replace, so effect same as if !replace was omitted
+        firstLevel2: !replace
+            secondLevel2: value2

--- a/test/test_yamlstratus.py
+++ b/test/test_yamlstratus.py
@@ -130,3 +130,156 @@ def test_load_as_json():
                 expected_json = all_expected_json[json_cnt]
                 compare_json(expected_json, actual_json)
                 json_cnt += 1
+
+
+def test_include_file_not_found():
+    yaml_str = """
+                ---
+                # Include root node of invalid file
+                main: !include unknown
+                ---
+                # Include invalid file
+                main:
+                    top: !include unknown
+                """
+    for yaml in yaml_str.split('---')[1:]:
+        try:
+            yamlstratus.load_as_json(yaml, include_dirs=["test"])
+            assert False
+        except IOError:
+            pass
+
+def test_include_error():
+    yaml_str = """
+                ---
+                # Include down one to unknown tag
+                main:
+                    top: !include test1.unknown
+                ---
+                # Include down many levels to unknown tag
+                main:
+                top: !include test1.level1.level2.level3.level4.unknown
+                """
+    for yaml in yaml_str.split('---')[1:]:
+        try:
+            yamlstratus.load_as_json(yaml, include_dirs=["test"])
+            assert False
+        except KeyError:
+            pass
+
+def test_include_base64_file_not_found():
+    yaml_str = """
+                ---
+                # Include
+                main: !include-base64 unknown.yaml
+                ---
+                # Include where suffix understood
+                main: !include-base64 unknown
+                """
+    for yaml in yaml_str.split('---')[1:]:
+        try:
+            yamlstratus.load_as_json(yaml, include_dirs=["test"])
+            assert False
+        except IOError:
+            pass
+
+def test_merge_syntax_errors():
+    yaml_str = """
+                ---
+                main:
+                    top: !merge
+                        startingFrom:
+                            - value1
+                            - value2
+                ---
+                main:
+                    top: !merge
+                        mergeWith:
+                            - value1
+                            - value2
+                ---
+                main:
+                    top: !merge
+                        startingWith:
+                            - value1
+                            - value2
+                        mergeFrom:
+                            - value1
+                            - value2
+                ---
+                main:
+                    top: !merge
+                        startingFrom:
+                            - value1
+                            - value2
+                        mergeWith:
+                            - value1
+                            - value2
+                        extraNode:
+                            - value1
+                            - value2
+                """
+    for yaml in yaml_str.split('---')[1:]:
+        try:
+            yamlstratus.load_as_json(yaml, include_dirs=["test"])
+            assert False
+        except KeyError:
+            pass
+
+def test_merge_type_mismatch_errors():
+    yaml_str = """
+                ---
+                main:
+                    top: !merge
+                        startingFrom:
+                            - value1
+                        mergeWith:
+                            key1: value1
+                ---
+                main:
+                    top: !merge
+                        startingFrom:
+                            key1: value1
+                        mergeWith:
+                            - value1
+                ---
+                main:
+                    top: !merge
+                        startingFrom:
+                            key1: value
+                        mergeWith: 123
+                ---
+                main:
+                    top: !merge
+                        startingFrom: 123
+                        mergeWith:
+                            key1: value
+                ---
+                main:
+                    top: !merge
+                        startingFrom:
+                            - value1
+                        mergeWith: 123
+                ---
+                main:
+                    top: !merge
+                        startingFrom: 123
+                        mergeWith:
+                            - value1
+                ---
+                main:
+                    top: !merge
+                        startingFrom: 123
+                        mergeWith: 123
+                ---
+                main:
+                    top: !merge
+                        startingFrom: value1
+                        mergeWith: value2
+                """
+    for yaml in yaml_str.split('---')[1:]:
+        try:
+            yamlstratus.load_as_json(yaml, include_dirs=["test"])
+            assert False
+        except ValueError:
+            pass


### PR DESCRIPTION
For a yaml script like
```
main: !merge
    startingFrom:
       key1: value1
    mergeWith: !merge
       startingFrom:
           key1: value2
      mergeWith:
          key1: value3
```

The inner merge was being ignored. This occurred only when the `startingFrom` or `mergeWith` node was itself a `!merge`.